### PR TITLE
fix: clear balance if the sdk fails to get it

### DIFF
--- a/.changeset/few-cherries-leave.md
+++ b/.changeset/few-cherries-leave.md
@@ -1,0 +1,18 @@
+---
+'@reown/appkit-ethers5-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+'@reown/appkit-auth-ethers-react-native': patch
+'@reown/appkit-auth-wagmi-react-native': patch
+'@reown/appkit-coinbase-ethers-react-native': patch
+'@reown/appkit-coinbase-wagmi-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-scaffold-react-native': patch
+'@reown/appkit-scaffold-utils-react-native': patch
+'@reown/appkit-siwe-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wallet-react-native': patch
+---
+
+fix: clear balance if the sdk fails to get it

--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -830,29 +830,33 @@ export class AppKit extends AppKitScaffold {
       const chain = this.chains.find(c => c.chainId === chainId);
       const token = this.options?.tokens?.[chainId];
 
-      if (chain) {
-        const jsonRpcProvider = new JsonRpcProvider(chain.rpcUrl, {
-          chainId,
-          name: chain.name
-        });
+      try {
+        if (chain) {
+          const jsonRpcProvider = new JsonRpcProvider(chain.rpcUrl, {
+            chainId,
+            name: chain.name
+          });
 
-        if (jsonRpcProvider) {
-          if (token) {
-            // Get balance from custom token address
-            const erc20 = new Contract(token.address, erc20ABI, jsonRpcProvider);
-            // @ts-expect-error
-            const decimals = await erc20.decimals();
-            // @ts-expect-error
-            const symbol = await erc20.symbol();
-            // @ts-expect-error
-            const balanceOf = await erc20.balanceOf(address);
-            this.setBalance(formatUnits(balanceOf, decimals), symbol);
-          } else {
-            const balance = await jsonRpcProvider.getBalance(address);
-            const formattedBalance = formatEther(balance);
-            this.setBalance(formattedBalance, chain.currency);
+          if (jsonRpcProvider) {
+            if (token) {
+              // Get balance from custom token address
+              const erc20 = new Contract(token.address, erc20ABI, jsonRpcProvider);
+              // @ts-expect-error
+              const decimals = await erc20.decimals();
+              // @ts-expect-error
+              const symbol = await erc20.symbol();
+              // @ts-expect-error
+              const balanceOf = await erc20.balanceOf(address);
+              this.setBalance(formatUnits(balanceOf, decimals), symbol);
+            } else {
+              const balance = await jsonRpcProvider.getBalance(address);
+              const formattedBalance = formatEther(balance);
+              this.setBalance(formattedBalance, chain.currency);
+            }
           }
         }
+      } catch {
+        this.setBalance(undefined, undefined);
       }
     }
   }

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -809,29 +809,32 @@ export class AppKit extends AppKitScaffold {
     if (chainId && this.chains) {
       const chain = this.chains.find(c => c.chainId === chainId);
       const token = this.options?.tokens?.[chainId];
-
-      if (chain) {
-        const jsonRpcProvider = new ethers.providers.JsonRpcProvider(chain.rpcUrl, {
-          chainId,
-          name: chain.name
-        });
-        if (jsonRpcProvider) {
-          if (token) {
-            // Get balance from custom token address
-            const erc20 = new Contract(token.address, erc20ABI, jsonRpcProvider);
-            // @ts-expect-error
-            const decimals = await erc20.decimals();
-            // @ts-expect-error
-            const symbol = await erc20.symbol();
-            // @ts-expect-error
-            const balanceOf = await erc20.balanceOf(address);
-            this.setBalance(utils.formatUnits(balanceOf, decimals), symbol);
-          } else {
-            const balance = await jsonRpcProvider.getBalance(address);
-            const formattedBalance = utils.formatEther(balance);
-            this.setBalance(formattedBalance, chain.currency);
+      try {
+        if (chain) {
+          const jsonRpcProvider = new ethers.providers.JsonRpcProvider(chain.rpcUrl, {
+            chainId,
+            name: chain.name
+          });
+          if (jsonRpcProvider) {
+            if (token) {
+              // Get balance from custom token address
+              const erc20 = new Contract(token.address, erc20ABI, jsonRpcProvider);
+              // @ts-expect-error
+              const decimals = await erc20.decimals();
+              // @ts-expect-error
+              const symbol = await erc20.symbol();
+              // @ts-expect-error
+              const balanceOf = await erc20.balanceOf(address);
+              this.setBalance(utils.formatUnits(balanceOf, decimals), symbol);
+            } else {
+              const balance = await jsonRpcProvider.getBalance(address);
+              const formattedBalance = utils.formatEther(balance);
+              this.setBalance(formattedBalance, chain.currency);
+            }
           }
         }
+      } catch {
+        this.setBalance(undefined, undefined);
       }
     }
   }

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -519,18 +519,22 @@ export class AppKit extends AppKitScaffold {
 
   private async syncBalance(address: Hex, chainId: number) {
     const chain = this.wagmiConfig.chains.find((c: Chain) => c.id === chainId);
-    if (chain) {
-      const balance = await getBalance(this.wagmiConfig, {
-        address,
-        chainId: chain.id,
-        token: this.options?.tokens?.[chainId]?.address as Hex
-      });
-      const formattedBalance = formatUnits(balance.value, balance.decimals);
-      this.setBalance(formattedBalance, balance.symbol);
+    try {
+      if (chain) {
+        const balance = await getBalance(this.wagmiConfig, {
+          address,
+          chainId: chain.id,
+          token: this.options?.tokens?.[chainId]?.address as Hex
+        });
+        const formattedBalance = formatUnits(balance.value, balance.decimals);
+        this.setBalance(formattedBalance, balance.symbol);
 
-      return;
+        return;
+      }
+      this.setBalance(undefined, undefined);
+    } catch {
+      this.setBalance(undefined, undefined);
     }
-    this.setBalance(undefined, undefined);
   }
 
   private async syncConnectedWalletInfo(connector: GetAccountReturnType['connector']) {


### PR DESCRIPTION
### Summary
* Added logic to cover failures when trying to get account's balance.

### Related
https://github.com/reown-com/appkit-react-native/issues/319