### PR TITLE
fix: check loaders before loading new page of wallets

### DIFF
--- a/.changeset/two-bikes-wave.md
+++ b/.changeset/two-bikes-wave.md
@@ -1,0 +1,18 @@
+---
+'@reown/appkit-scaffold-react-native': patch
+'@reown/appkit-ethers5-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-siwe-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-auth-ethers-react-native': patch
+'@reown/appkit-auth-wagmi-react-native': patch
+'@reown/appkit-coinbase-ethers-react-native': patch
+'@reown/appkit-coinbase-wagmi-react-native': patch
+'@reown/appkit-scaffold-utils-react-native': patch
+'@reown/appkit-wallet-react-native': patch
+---
+
+fix: solved issue with wallet page loaders

--- a/packages/scaffold/src/partials/w3m-all-wallets-list/index.tsx
+++ b/packages/scaffold/src/partials/w3m-all-wallets-list/index.tsx
@@ -28,7 +28,7 @@ interface AllWalletsListProps {
 }
 
 export function AllWalletsList({ columns, itemWidth, onItemPress }: AllWalletsListProps) {
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(ApiController.state.wallets.length === 0);
   const [loadingError, setLoadingError] = useState<boolean>(false);
   const [pageLoading, setPageLoading] = useState<boolean>(false);
   const { maxWidth, padding } = useCustomDimensions();
@@ -115,7 +115,12 @@ export function AllWalletsList({ columns, itemWidth, onItemPress }: AllWalletsLi
 
   const fetchNextPage = async () => {
     try {
-      if (walletList.length < ApiController.state.count && !pageLoading) {
+      if (
+        walletList.length < ApiController.state.count &&
+        !pageLoading &&
+        !loading &&
+        ApiController.state.page > 0
+      ) {
         setPageLoading(true);
         await ApiController.fetchWallets({ page: ApiController.state.page + 1 });
         setPageLoading(false);


### PR DESCRIPTION
### Summary
* Check for loaders before loading a new page in all wallet lists. This was causing an issue of multiple pages being loaded at the same time