### PR TITLE
fix: disable cover screen in modal

### DIFF
--- a/.changeset/thin-files-play.md
+++ b/.changeset/thin-files-play.md
@@ -1,0 +1,18 @@
+---
+'@reown/appkit-scaffold-react-native': patch
+'@reown/appkit-auth-ethers-react-native': patch
+'@reown/appkit-auth-wagmi-react-native': patch
+'@reown/appkit-coinbase-ethers-react-native': patch
+'@reown/appkit-coinbase-wagmi-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-ethers5-react-native': patch
+'@reown/appkit-scaffold-utils-react-native': patch
+'@reown/appkit-siwe-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+'@reown/appkit-wallet-react-native': patch
+---
+
+fix: disable coverscreen on root modal to solve issues with expo-router

--- a/packages/scaffold/src/modal/w3m-modal/index.tsx
+++ b/packages/scaffold/src/modal/w3m-modal/index.tsx
@@ -16,7 +16,6 @@ import {
   TransactionsController,
   type CaipAddress,
   type AppKitFrameProvider,
-  WebviewController,
   ThemeController
 } from '@reown/appkit-core-react-native';
 import { SIWEController } from '@reown/appkit-siwe-react-native';
@@ -31,7 +30,6 @@ export function AppKit() {
   const { open, loading } = useSnapshot(ModalController.state);
   const { connectors, connectedConnector } = useSnapshot(ConnectorController.state);
   const { caipAddress, isConnected } = useSnapshot(AccountController.state);
-  const { frameViewVisible, webviewVisible } = useSnapshot(WebviewController.state);
   const { themeMode, themeVariables } = useSnapshot(ThemeController.state);
   const { height } = useWindowDimensions();
   const { isLandscape } = useCustomDimensions();

--- a/packages/scaffold/src/modal/w3m-modal/index.tsx
+++ b/packages/scaffold/src/modal/w3m-modal/index.tsx
@@ -121,7 +121,7 @@ export function AppKit() {
       <ThemeProvider themeMode={themeMode} themeVariables={themeVariables}>
         <Modal
           style={styles.modal}
-          coverScreen={!frameViewVisible && !webviewVisible}
+          coverScreen={false}
           isVisible={open}
           useNativeDriver
           useNativeDriverForBackdrop


### PR DESCRIPTION
### Summary
Disabled `coverScreen` prop to solve issues with expo-router on Android