### PR TITLE
chore: replace internal URL usage

### DIFF
--- a/.changeset/rotten-pianos-argue.md
+++ b/.changeset/rotten-pianos-argue.md
@@ -1,0 +1,18 @@
+---
+'@reown/appkit-coinbase-ethers-react-native': patch
+'@reown/appkit-coinbase-wagmi-react-native': patch
+'@reown/appkit-scaffold-utils-react-native': patch
+'@reown/appkit-auth-ethers-react-native': patch
+'@reown/appkit-auth-wagmi-react-native': patch
+'@reown/appkit-scaffold-react-native': patch
+'@reown/appkit-ethers5-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-wallet-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-siwe-react-native': patch
+'@reown/appkit-ui-react-native': patch
+---
+
+chore: replace internal URL usage with custom logic to avoid polyfill issues

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
     "react-hooks/exhaustive-deps": "warn",
     "no-console": ["error", { "allow": ["warn"] }],
     "newline-before-return": "error",
-    "radix": "off"
+    "radix": "off",
+    "dot-notation": "off"
   },
   "parserOptions": {
     "requireConfigFile": false

--- a/packages/core/src/__tests__/utils/FetchUtil.test.ts
+++ b/packages/core/src/__tests__/utils/FetchUtil.test.ts
@@ -1,0 +1,107 @@
+import { FetchUtil } from '../../utils/FetchUtil';
+
+describe('FetchUtil', () => {
+  const baseUrl = 'https://api.example.com';
+  const clientId = 'test-client-id';
+
+  describe('createUrl', () => {
+    it('should construct a simple URL with a relative path', () => {
+      const fetchUtil = new FetchUtil({ baseUrl });
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'test' });
+      expect(url).toBe('https://api.example.com/test');
+    });
+
+    it('should handle base URL without a trailing slash', () => {
+      const fetchUtil = new FetchUtil({ baseUrl: 'https://api.example.com' });
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'test' });
+      expect(url).toBe('https://api.example.com/test');
+    });
+
+    it('should handle base URL with a trailing slash', () => {
+      const fetchUtil = new FetchUtil({ baseUrl: 'https://api.example.com/' });
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'test' });
+      expect(url).toBe('https://api.example.com/test');
+    });
+
+    it('should handle relative path with a leading slash', () => {
+      const fetchUtil = new FetchUtil({ baseUrl });
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: '/test' });
+      expect(url).toBe('https://api.example.com/test');
+    });
+
+    it('should use the path as is if it is an absolute URL', () => {
+      const fetchUtil = new FetchUtil({ baseUrl });
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'https://another.com/test' });
+      expect(url).toBe('https://another.com/test');
+    });
+
+    it('should add query parameters to the URL', () => {
+      const fetchUtil = new FetchUtil({ baseUrl });
+      const params = { foo: 'bar', baz: 'qux' };
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'test', params });
+      expect(url).toBe('https://api.example.com/test?foo=bar&baz=qux');
+    });
+
+    it('should add clientId as a query parameter if provided', () => {
+      const fetchUtil = new FetchUtil({ baseUrl, clientId });
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'test' });
+      expect(url).toBe('https://api.example.com/test?clientId=test-client-id');
+    });
+
+    it('should combine clientId and other query parameters', () => {
+      const fetchUtil = new FetchUtil({ baseUrl, clientId });
+      const params = { foo: 'bar' };
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'test', params });
+      expect(url).toBe('https://api.example.com/test?foo=bar&clientId=test-client-id');
+    });
+
+    it('should append to existing query parameters in the path', () => {
+      const fetchUtil = new FetchUtil({ baseUrl });
+      const params = { baz: 'qux' };
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'test?foo=bar', params });
+      expect(url).toBe('https://api.example.com/test?foo=bar&baz=qux');
+    });
+
+    it('should correctly encode special characters in parameters', () => {
+      const fetchUtil = new FetchUtil({ baseUrl });
+      const params = { 'key with space': 'value with &' };
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'test', params });
+      const expectedUrl = 'https://api.example.com/test?key%20with%20space=value%20with%20%26';
+      expect(url).toBe(expectedUrl);
+    });
+
+    it('should ignore undefined parameter values', () => {
+      const fetchUtil = new FetchUtil({ baseUrl });
+      const params = { foo: 'bar', baz: undefined };
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'test', params });
+      expect(url).toBe('https://api.example.com/test?foo=bar');
+    });
+
+    it('should handle absolute URL with params', () => {
+      const fetchUtil = new FetchUtil({ baseUrl });
+      const params = { foo: 'bar' };
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'https://another.com/test', params });
+      expect(url).toBe('https://another.com/test?foo=bar');
+    });
+
+    it('should handle absolute URL with existing params and new params', () => {
+      const fetchUtil = new FetchUtil({ baseUrl, clientId });
+      const params = { bar: 'baz' };
+      // @ts-expect-error Testing private method
+      const url = fetchUtil.createUrl({ path: 'https://another.com/test?foo=bar', params });
+      expect(url).toBe('https://another.com/test?foo=bar&bar=baz&clientId=test-client-id');
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces several updates, including enhancements to URL generation logic, additional test coverage for the `FetchUtil` utility, and minor configuration changes. The most significant changes focus on improving the handling of URL construction and query parameters in the `FetchUtil` class.

### Enhancements to `FetchUtil` URL generation:
* Refactored the `createUrl` method in `FetchUtil` to replace the use of the `URL` class with custom logic for constructing URLs. This change ensures compatibility with environments that lack `URL` support. The new implementation handles absolute and relative paths, trailing slashes, and query parameter encoding more robustly. (`packages/core/src/utils/FetchUtil.ts`)

### Additional test coverage:
* Added comprehensive unit tests for the `FetchUtil` utility, specifically for the `createUrl` method. These tests cover various scenarios, including handling absolute and relative URLs, query parameters, special characters, and edge cases like undefined parameter values. (`packages/core/src/__tests__/utils/FetchUtil.test.ts`)