### PR TITLE
fix: get the connector id before setting the approved networks

### DIFF
--- a/.changeset/ready-books-march.md
+++ b/.changeset/ready-books-march.md
@@ -1,0 +1,19 @@
+---
+'@reown/appkit-scaffold-react-native': patch
+'@reown/appkit-ethers5-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-auth-ethers-react-native': patch
+'@reown/appkit-auth-wagmi-react-native': patch
+'@reown/appkit-react-native-cli': patch
+'@reown/appkit-coinbase-ethers-react-native': patch
+'@reown/appkit-coinbase-wagmi-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-scaffold-utils-react-native': patch
+'@reown/appkit-siwe-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-wallet-react-native': patch
+---
+
+fix: correctly set approved networks and support all networks flag

--- a/packages/core/src/controllers/ConnectorController.ts
+++ b/packages/core/src/controllers/ConnectorController.ts
@@ -42,7 +42,7 @@ export const ConnectorController = {
     return state.connectors.find(c => c.type === 'AUTH');
   },
 
-  setConnectedConnector(
+  async setConnectedConnector(
     connectorType: ConnectorControllerState['connectedConnector'],
     saveStorage = true
   ) {
@@ -50,9 +50,9 @@ export const ConnectorController = {
 
     if (saveStorage) {
       if (connectorType) {
-        StorageUtil.setConnectedConnector(connectorType);
+        await StorageUtil.setConnectedConnector(connectorType);
       } else {
-        StorageUtil.removeConnectedConnector();
+        await StorageUtil.removeConnectedConnector();
       }
     }
   },

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -1,13 +1,13 @@
 import { proxy, ref } from 'valtio';
 import type { CaipNetwork, CaipNetworkId } from '../utils/TypeUtil';
 import { PublicStateController } from './PublicStateController';
-import { NetworkUtil } from '@reown/appkit-common-react-native';
+import { NetworkUtil, type ConnectorType } from '@reown/appkit-common-react-native';
 import { ConstantsUtil } from '../utils/ConstantsUtil';
 
 // -- Types --------------------------------------------- //
 export interface NetworkControllerClient {
   switchCaipNetwork: (network: NetworkControllerState['caipNetwork']) => Promise<void>;
-  getApprovedCaipNetworksData: () => Promise<{
+  getApprovedCaipNetworksData: (connectorType?: ConnectorType) => Promise<{
     approvedCaipNetworkIds: NetworkControllerState['approvedCaipNetworkIds'];
     supportsAllNetworks: NetworkControllerState['supportsAllNetworks'];
   }>;
@@ -77,8 +77,8 @@ export const NetworkController = {
     return Boolean(state.smartAccountEnabledNetworks?.includes(Number(networkId)));
   },
 
-  async getApprovedCaipNetworksData() {
-    const data = await this._getClient().getApprovedCaipNetworksData();
+  async getApprovedCaipNetworksData(connectorType?: ConnectorType) {
+    const data = await this._getClient().getApprovedCaipNetworksData(connectorType);
     state.supportsAllNetworks = data.supportsAllNetworks;
     state.approvedCaipNetworkIds = data.approvedCaipNetworkIds;
   },

--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -139,7 +139,8 @@ export class AppKit extends AppKitScaffold {
 
       getApprovedCaipNetworksData: async () =>
         new Promise(async resolve => {
-          const walletChoice = await StorageUtil.getConnectedConnector();
+          const walletId = (await StorageUtil.getItem(EthersConstantsUtil.WALLET_ID)) as string;
+          const walletChoice = PresetsUtil.ConnectorTypesMap[walletId ?? ''];
           const walletConnectType =
             PresetsUtil.ConnectorTypesMap[ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID]!;
 

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -126,7 +126,8 @@ export class AppKit extends AppKitScaffold {
 
       getApprovedCaipNetworksData: async () =>
         new Promise(async resolve => {
-          const walletChoice = await StorageUtil.getConnectedConnector();
+          const walletId = (await StorageUtil.getItem(EthersConstantsUtil.WALLET_ID)) as string;
+          const walletChoice = PresetsUtil.ConnectorTypesMap[walletId ?? ''];
           const walletConnectType =
             PresetsUtil.ConnectorTypesMap[ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID]!;
 

--- a/packages/scaffold/src/client.ts
+++ b/packages/scaffold/src/client.ts
@@ -33,6 +33,7 @@ import { SIWEController, type SIWEControllerClient } from '@reown/appkit-siwe-re
 import {
   ConstantsUtil,
   ErrorUtil,
+  type ConnectorType,
   type ThemeMode,
   type ThemeVariables
 } from '@reown/appkit-common-react-native';
@@ -197,7 +198,7 @@ export class AppKitScaffold {
     };
 
   protected getApprovedCaipNetworksData: (typeof NetworkController)['getApprovedCaipNetworksData'] =
-    () => NetworkController.getApprovedCaipNetworksData();
+    (connectorType?: ConnectorType) => NetworkController.getApprovedCaipNetworksData(connectorType);
 
   protected resetNetwork: (typeof NetworkController)['resetNetwork'] = () => {
     NetworkController.resetNetwork();

--- a/packages/scaffold/src/views/w3m-connecting-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-connecting-view/index.tsx
@@ -50,7 +50,7 @@ export function ConnectingView() {
         ConnectionController.setWcError(false);
         ConnectionController.connectWalletConnect(routeData?.wallet?.link_mode ?? undefined);
         await ConnectionController.state.wcPromise;
-        ConnectorController.setConnectedConnector('WALLET_CONNECT');
+        await ConnectorController.setConnectedConnector('WALLET_CONNECT');
         AccountController.setIsConnected(true);
 
         if (OptionsController.state.isSiweEnabled) {

--- a/packages/wagmi/src/client.ts
+++ b/packages/wagmi/src/client.ts
@@ -111,20 +111,19 @@ export class AppKit extends AppKitScaffold {
         }
       },
 
-      async getApprovedCaipNetworksData() {
-        const walletChoice = await StorageUtil.getConnectedConnector();
+      async getApprovedCaipNetworksData(connectorType?: ConnectorType) {
         const walletConnectType =
           PresetsUtil.ConnectorTypesMap[ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID]!;
 
         const authType = PresetsUtil.ConnectorTypesMap[ConstantsUtil.AUTH_CONNECTOR_ID]!;
 
-        if (walletChoice?.includes(walletConnectType)) {
+        if (connectorType?.includes(walletConnectType)) {
           const connector = wagmiConfig.connectors.find(
             c => c.id === ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID
           );
 
           return getWalletConnectCaipNetworks(connector);
-        } else if (authType) {
+        } else if (connectorType?.includes(authType)) {
           return getAuthCaipNetworks();
         }
 
@@ -443,11 +442,12 @@ export class AppKit extends AppKitScaffold {
       const caipAddress: CaipAddress = `${ConstantsUtil.EIP155}:${chainId}:${address}`;
       this.setIsConnected(isConnected);
       this.setCaipAddress(caipAddress);
+      const connectorType = PresetsUtil.ConnectorTypesMap[connector?.id ?? ''];
       await Promise.all([
         this.syncProfile(address, chainId),
         this.syncBalance(address, chainId),
         this.syncConnectedWalletInfo(connector),
-        this.getApprovedCaipNetworksData()
+        this.getApprovedCaipNetworksData(connectorType)
       ]);
       this.hasSyncedConnectedAccount = true;
     } else if (!isConnected && !isConnecting && !isReconnecting && this.hasSyncedConnectedAccount) {


### PR DESCRIPTION
This pull request introduces improvements to how connector types are handled and passed throughout the codebase, especially for network approval logic. The main changes include updating function signatures to consistently accept and use a `connectorType` parameter, ensuring asynchronous storage operations, and refactoring logic to use connector IDs for type resolution. These updates enhance clarity, consistency, and reliability in managing wallet connections and network approvals.

**Connector type handling and propagation:**

* Updated the signature of `getApprovedCaipNetworksData` in `NetworkController` and related client classes to accept an optional `connectorType` parameter, allowing more precise control over network approval logic. [[1]](diffhunk://#diff-497fa93386abef4e0c3a631f0ef0d68f0b97d50776e61b4f9dd82a83607cce35L4-R10) [[2]](diffhunk://#diff-497fa93386abef4e0c3a631f0ef0d68f0b97d50776e61b4f9dd82a83607cce35L80-R81) [[3]](diffhunk://#diff-2ea35275b67e8352c4a448ac5b7a1349ebe15f18c84c1cda1359071cf947f7a3L200-R201) [[4]](diffhunk://#diff-db30b0aed80e68d75fc6020101784ee3e0af77d8f349f10540d2b0f2506c9218L114-R126)
* Refactored logic in `packages/ethers/src/client.ts` and `packages/ethers5/src/client.ts` to resolve `walletChoice` using connector IDs and the `ConnectorTypesMap`, improving type resolution and consistency. [[1]](diffhunk://#diff-a589763fd198bf28ae1bd7fa52a62b1b75c8ecc54c7dfecb0cfa0e2d824fc3ddL142-R143) [[2]](diffhunk://#diff-184d5b3e7a581c5b0cd208de9da1c0ea4981c7c93e4c05f99af5e20f2d897478L129-R130)
* Updated `AppKit` in `packages/wagmi/src/client.ts` to pass the resolved `connectorType` to `getApprovedCaipNetworksData` during account synchronization, ensuring correct network approval per connector.

**Asynchronous storage operations:**

* Made `ConnectorController.setConnectedConnector` asynchronous and updated all usages to `await` its execution, ensuring storage operations complete before proceeding. [[1]](diffhunk://#diff-952b2e72ab1ad94e5cbe74c69d39883bb696f06439ce013040591b6d8b6fd3bdL45-R55) [[2]](diffhunk://#diff-3709b9010fdb7e1fb7e6c197caa4823d43a870f97806c156b7c27efc237bda77L53-R53)

**Type and import improvements:**

* Added explicit imports for `ConnectorType` in relevant files to support new function signatures and type safety.