### PR TITLE
fix: network images loading

### DIFF
--- a/.changeset/six-dots-punch.md
+++ b/.changeset/six-dots-punch.md
@@ -1,0 +1,18 @@
+---
+'@reown/appkit-scaffold-react-native': patch
+'@reown/appkit-core-react-native': patch
+'@reown/appkit-ui-react-native': patch
+'@reown/appkit-auth-ethers-react-native': patch
+'@reown/appkit-auth-wagmi-react-native': patch
+'@reown/appkit-coinbase-ethers-react-native': patch
+'@reown/appkit-coinbase-wagmi-react-native': patch
+'@reown/appkit-common-react-native': patch
+'@reown/appkit-ethers-react-native': patch
+'@reown/appkit-ethers5-react-native': patch
+'@reown/appkit-scaffold-utils-react-native': patch
+'@reown/appkit-siwe-react-native': patch
+'@reown/appkit-wagmi-react-native': patch
+'@reown/appkit-wallet-react-native': patch
+---
+
+fix: show network images correctly

--- a/packages/core/src/utils/AssetUtil.ts
+++ b/packages/core/src/utils/AssetUtil.ts
@@ -14,16 +14,16 @@ export const AssetUtil = {
     return undefined;
   },
 
-  getNetworkImage(network?: CaipNetwork) {
+  getNetworkImage(network?: CaipNetwork, networkImages?: Record<string, string>) {
+    if (!network || !network?.imageId) {
+      return undefined;
+    }
+
     if (network?.imageUrl) {
-      return network?.imageUrl;
+      return network.imageUrl;
     }
 
-    if (network?.imageId) {
-      return AssetController.state.networkImages[network.imageId];
-    }
-
-    return undefined;
+    return networkImages?.[network?.imageId];
   },
 
   getConnectorImage(connector?: Connector) {

--- a/packages/core/src/utils/AssetUtil.ts
+++ b/packages/core/src/utils/AssetUtil.ts
@@ -15,15 +15,19 @@ export const AssetUtil = {
   },
 
   getNetworkImage(network?: CaipNetwork, networkImages?: Record<string, string>) {
-    if (!network || !network?.imageId) {
+    if (!network) {
       return undefined;
     }
 
-    if (network?.imageUrl) {
+    if (network.imageUrl) {
       return network.imageUrl;
     }
 
-    return networkImages?.[network?.imageId];
+    if (network.imageId) {
+      return networkImages?.[network.imageId];
+    }
+
+    return undefined;
   },
 
   getConnectorImage(connector?: Connector) {

--- a/packages/scaffold/src/modal/w3m-account-button/index.tsx
+++ b/packages/scaffold/src/modal/w3m-account-button/index.tsx
@@ -7,7 +7,8 @@ import {
   ModalController,
   AssetUtil,
   ThemeController,
-  ApiController
+  ApiController,
+  AssetController
 } from '@reown/appkit-core-react-native';
 import { AccountButton as AccountButtonUI, ThemeProvider } from '@reown/appkit-ui-react-native';
 
@@ -27,9 +28,10 @@ export function AccountButton({ balance, disabled, style, testID }: AccountButto
     profileName
   } = useSnapshot(AccountController.state);
   const { caipNetwork } = useSnapshot(NetworkController.state);
+  const { networkImages } = useSnapshot(AssetController.state);
   const { themeMode, themeVariables } = useSnapshot(ThemeController.state);
 
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
   const showBalance = balance === 'show';
 
   return (

--- a/packages/scaffold/src/modal/w3m-network-button/index.tsx
+++ b/packages/scaffold/src/modal/w3m-network-button/index.tsx
@@ -3,6 +3,7 @@ import type { StyleProp, ViewStyle } from 'react-native';
 import {
   AccountController,
   ApiController,
+  AssetController,
   AssetUtil,
   EventsController,
   ModalController,
@@ -18,6 +19,7 @@ export interface NetworkButtonProps {
 
 export function NetworkButton({ disabled, style }: NetworkButtonProps) {
   const { isConnected } = useSnapshot(AccountController.state);
+  const { networkImages } = useSnapshot(AssetController.state);
   const { caipNetwork } = useSnapshot(NetworkController.state);
   const { loading } = useSnapshot(ModalController.state);
   const { themeMode, themeVariables } = useSnapshot(ThemeController.state);
@@ -33,7 +35,7 @@ export function NetworkButton({ disabled, style }: NetworkButtonProps) {
   return (
     <ThemeProvider themeMode={themeMode} themeVariables={themeVariables}>
       <NetworkButtonUI
-        imageSrc={AssetUtil.getNetworkImage(caipNetwork)}
+        imageSrc={AssetUtil.getNetworkImage(caipNetwork, networkImages)}
         imageHeaders={ApiController._getApiHeaders()}
         disabled={disabled || loading}
         style={style}

--- a/packages/scaffold/src/partials/w3m-account-activity/index.tsx
+++ b/packages/scaffold/src/partials/w3m-account-activity/index.tsx
@@ -13,6 +13,7 @@ import {
 import { type Transaction, type TransactionImage } from '@reown/appkit-common-react-native';
 import {
   AccountController,
+  AssetController,
   AssetUtil,
   EventsController,
   NetworkController,
@@ -33,7 +34,8 @@ export function AccountActivity({ style }: Props) {
   const [initialLoad, setInitialLoad] = useState(true);
   const { loading, transactions, next } = useSnapshot(TransactionsController.state);
   const { caipNetwork } = useSnapshot(NetworkController.state);
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const { networkImages } = useSnapshot(AssetController.state);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
 
   const handleLoadMore = () => {
     TransactionsController.fetchTransactions(AccountController.state.address);

--- a/packages/scaffold/src/partials/w3m-account-tokens/index.tsx
+++ b/packages/scaffold/src/partials/w3m-account-tokens/index.tsx
@@ -9,6 +9,7 @@ import {
 import { useSnapshot } from 'valtio';
 import {
   AccountController,
+  AssetController,
   AssetUtil,
   NetworkController,
   RouterController
@@ -31,7 +32,8 @@ export function AccountTokens({ style }: Props) {
   const [refreshing, setRefreshing] = useState(false);
   const { tokenBalance } = useSnapshot(AccountController.state);
   const { caipNetwork } = useSnapshot(NetworkController.state);
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const { networkImages } = useSnapshot(AssetController.state);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);

--- a/packages/scaffold/src/partials/w3m-selector-modal/index.tsx
+++ b/packages/scaffold/src/partials/w3m-selector-modal/index.tsx
@@ -13,7 +13,7 @@ import {
   useTheme
 } from '@reown/appkit-ui-react-native';
 import styles from './styles';
-import { AssetUtil, NetworkController } from '@reown/appkit-core-react-native';
+import { AssetController, AssetUtil, NetworkController } from '@reown/appkit-core-react-native';
 
 interface SelectorModalProps {
   title?: string;
@@ -46,7 +46,8 @@ export function SelectorModal({
 }: SelectorModalProps) {
   const Theme = useTheme();
   const { caipNetwork } = useSnapshot(NetworkController.state);
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const { networkImages } = useSnapshot(AssetController.state);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
 
   const renderSeparator = () => {
     return <View style={{ height: SEPARATOR_HEIGHT }} />;

--- a/packages/scaffold/src/views/w3m-account-default-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-account-default-view/index.tsx
@@ -18,7 +18,8 @@ import {
   type AppKitFrameProvider,
   ConstantsUtil,
   SwapController,
-  OnRampController
+  OnRampController,
+  AssetController
 } from '@reown/appkit-core-react-native';
 import {
   Avatar,
@@ -52,7 +53,8 @@ export function AccountDefaultView() {
   const { connectedSocialProvider } = useSnapshot(ConnectionController.state);
   const { features, isOnRampEnabled } = useSnapshot(OptionsController.state);
   const { history } = useSnapshot(RouterController.state);
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const { networkImages } = useSnapshot(AssetController.state);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
   const showCopy = OptionsController.isClipboardAvailable();
   const isAuth = connectedConnector === 'AUTH';
   const showBalance = balance && !isAuth;

--- a/packages/scaffold/src/views/w3m-account-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-account-view/index.tsx
@@ -13,6 +13,7 @@ import {
 import {
   AccountController,
   ApiController,
+  AssetController,
   AssetUtil,
   ModalController,
   NetworkController,
@@ -28,6 +29,7 @@ export function AccountView() {
   const Theme = useTheme();
   const { padding } = useCustomDimensions();
   const { caipNetwork } = useSnapshot(NetworkController.state);
+  const { networkImages } = useSnapshot(AssetController.state);
   const { address, profileName, profileImage, preferredAccountType } = useSnapshot(
     AccountController.state
   );
@@ -74,7 +76,7 @@ export function AccountView() {
       ]}
     >
       <NetworkButton
-        imageSrc={AssetUtil.getNetworkImage(caipNetwork)}
+        imageSrc={AssetUtil.getNetworkImage(caipNetwork, networkImages)}
         imageHeaders={ApiController._getApiHeaders()}
         onPress={onNetworkPress}
         style={styles.networkIcon}

--- a/packages/scaffold/src/views/w3m-network-switch-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-network-switch-view/index.tsx
@@ -3,6 +3,7 @@ import { useSnapshot } from 'valtio';
 import { useEffect, useState } from 'react';
 import {
   ApiController,
+  AssetController,
   AssetUtil,
   ConnectionController,
   ConnectorController,
@@ -21,10 +22,13 @@ import {
 } from '@reown/appkit-ui-react-native';
 import styles from './styles';
 
+const imageHeaders = ApiController._getApiHeaders();
+
 export function NetworkSwitchView() {
   const { data } = useSnapshot(RouterController.state);
   const { recentWallets } = useSnapshot(ConnectionController.state);
   const { caipNetwork } = useSnapshot(NetworkController.state);
+  const { networkImages } = useSnapshot(AssetController.state);
   const isAuthConnected = ConnectorController.state.connectedConnector === 'AUTH';
   const [error, setError] = useState<boolean>(false);
   const [showRetry, setShowRetry] = useState<boolean>(false);
@@ -115,8 +119,8 @@ export function NetworkSwitchView() {
     <FlexView alignItems="center" padding={['2xl', 's', '4xl', 's']}>
       <LoadingHexagon paused={error}>
         <NetworkImage
-          imageSrc={AssetUtil.getNetworkImage(network)}
-          imageHeaders={ApiController._getApiHeaders()}
+          imageSrc={AssetUtil.getNetworkImage(network, networkImages)}
+          imageHeaders={imageHeaders}
           size="lg"
         />
         {error && (

--- a/packages/scaffold/src/views/w3m-networks-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-networks-view/index.tsx
@@ -1,3 +1,4 @@
+import { useSnapshot } from 'valtio';
 import { ScrollView, View } from 'react-native';
 import {
   CardSelect,
@@ -16,7 +17,8 @@ import {
   type CaipNetwork,
   EventsController,
   CoreHelperUtil,
-  NetworkUtil
+  NetworkUtil,
+  AssetController
 } from '@reown/appkit-core-react-native';
 import { useCustomDimensions } from '../../hooks/useCustomDimensions';
 import styles from './styles';
@@ -24,6 +26,7 @@ import styles from './styles';
 export function NetworksView() {
   const { caipNetwork, requestedCaipNetworks, approvedCaipNetworkIds, supportsAllNetworks } =
     NetworkController.state;
+  const { networkImages } = useSnapshot(AssetController.state);
   const imageHeaders = ApiController._getApiHeaders();
   const { maxWidth: width, padding } = useCustomDimensions();
   const numColumns = 4;
@@ -69,7 +72,7 @@ export function NetworksView() {
           testID={`w3m-network-switch-${network.name ?? network.id}`}
           name={network.name ?? 'Unknown'}
           type="network"
-          imageSrc={AssetUtil.getNetworkImage(network)}
+          imageSrc={AssetUtil.getNetworkImage(network, networkImages)}
           imageHeaders={imageHeaders}
           disabled={!supportsAllNetworks && !approvedCaipNetworkIds?.includes(network.id)}
           selected={caipNetwork?.id === network.id}

--- a/packages/scaffold/src/views/w3m-onramp-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-onramp-view/index.tsx
@@ -10,7 +10,8 @@ import {
   NetworkController,
   AssetUtil,
   SnackController,
-  ConstantsUtil
+  ConstantsUtil,
+  AssetController
 } from '@reown/appkit-core-react-native';
 import {
   Button,
@@ -50,12 +51,13 @@ export function OnRampView() {
     initialLoading
   } = useSnapshot(OnRampController.state) as OnRampControllerState;
   const { caipNetwork } = useSnapshot(NetworkController.state);
+  const { networkImages } = useSnapshot(AssetController.state);
   const [searchValue, setSearchValue] = useState('');
   const [isCurrencyModalVisible, setIsCurrencyModalVisible] = useState(false);
   const [isPaymentMethodModalVisible, setIsPaymentMethodModalVisible] = useState(false);
   const purchaseCurrencyCode =
     purchaseCurrency?.currencyCode?.split('_')[0] ?? purchaseCurrency?.currencyCode;
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
 
   const getQuotes = useCallback(() => {
     if (OnRampController.canGenerateQuote()) {

--- a/packages/scaffold/src/views/w3m-swap-select-token-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-swap-select-token-view/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '@reown/appkit-ui-react-native';
 
 import {
+  AssetController,
   AssetUtil,
   NetworkController,
   RouterController,
@@ -30,7 +31,8 @@ export function SwapSelectTokenView() {
   const Theme = useTheme();
   const { caipNetwork } = useSnapshot(NetworkController.state);
   const { sourceToken, suggestedTokens } = useSnapshot(SwapController.state);
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const { networkImages } = useSnapshot(AssetController.state);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
   const [tokenSearch, setTokenSearch] = useState<string>('');
   const isSourceToken = RouterController.state.data?.swapTarget === 'sourceToken';
 

--- a/packages/scaffold/src/views/w3m-unsupported-chain-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-unsupported-chain-view/index.tsx
@@ -11,13 +11,15 @@ import {
   NetworkController,
   NetworkUtil,
   type CaipNetwork,
-  type NetworkControllerState
+  type NetworkControllerState,
+  AssetController
 } from '@reown/appkit-core-react-native';
 import styles from './styles';
 
 export function UnsupportedChainView() {
   const { caipNetwork, supportsAllNetworks, approvedCaipNetworkIds, requestedCaipNetworks } =
     useSnapshot(NetworkController.state) as NetworkControllerState;
+  const { networkImages } = useSnapshot(AssetController.state);
 
   const [disconnecting, setDisconnecting] = useState(false);
   const networks = CoreHelperUtil.sortNetworks(approvedCaipNetworkIds, requestedCaipNetworks);
@@ -59,7 +61,7 @@ export function UnsupportedChainView() {
           key={item.id}
           icon="networkPlaceholder"
           iconBackgroundColor="gray-glass-010"
-          imageSrc={AssetUtil.getNetworkImage(item)}
+          imageSrc={AssetUtil.getNetworkImage(item, networkImages)}
           imageHeaders={imageHeaders}
           onPress={() => onNetworkPress(item)}
           testID="button-network"

--- a/packages/scaffold/src/views/w3m-wallet-compatible-networks-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-wallet-compatible-networks-view/index.tsx
@@ -4,6 +4,7 @@ import { FlexView, Text, Banner, NetworkImage } from '@reown/appkit-ui-react-nat
 import {
   AccountController,
   ApiController,
+  AssetController,
   AssetUtil,
   NetworkController
 } from '@reown/appkit-core-react-native';
@@ -13,6 +14,7 @@ import styles from './styles';
 export function WalletCompatibleNetworks() {
   const { padding } = useCustomDimensions();
   const { preferredAccountType } = useSnapshot(AccountController.state);
+  const { networkImages } = useSnapshot(AssetController.state);
   const isSmartAccount =
     preferredAccountType === 'smartAccount' && NetworkController.checkIfSmartAccountEnabled();
   const approvedNetworks = isSmartAccount
@@ -32,7 +34,7 @@ export function WalletCompatibleNetworks() {
             padding={['s', 's', 's', 's']}
           >
             <NetworkImage
-              imageSrc={AssetUtil.getNetworkImage(network)}
+              imageSrc={AssetUtil.getNetworkImage(network, networkImages)}
               imageHeaders={imageHeaders}
               size="sm"
               style={styles.image}

--- a/packages/scaffold/src/views/w3m-wallet-receive-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-wallet-receive-view/index.tsx
@@ -12,6 +12,7 @@ import {
 import {
   AccountController,
   ApiController,
+  AssetController,
   AssetUtil,
   NetworkController,
   OptionsController,
@@ -23,7 +24,8 @@ import { useCustomDimensions } from '../../hooks/useCustomDimensions';
 export function WalletReceiveView() {
   const { address, profileName, preferredAccountType } = useSnapshot(AccountController.state);
   const { caipNetwork } = useSnapshot(NetworkController.state);
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const { networkImages } = useSnapshot(AssetController.state);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
   const { padding } = useCustomDimensions();
   const canCopy = OptionsController.isClipboardAvailable();
   const isSmartAccount =
@@ -35,7 +37,7 @@ export function WalletReceiveView() {
   const imagesArray = networks
     .filter(network => network?.imageId)
     .slice(0, 5)
-    .map(AssetUtil.getNetworkImage)
+    .map(network => AssetUtil.getNetworkImage(network, networkImages))
     .filter(Boolean) as string[];
 
   const label = UiUtil.getTruncateString({

--- a/packages/scaffold/src/views/w3m-wallet-receive-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-wallet-receive-view/index.tsx
@@ -37,7 +37,7 @@ export function WalletReceiveView() {
   const imagesArray = networks
     .filter(network => network?.imageId)
     .slice(0, 5)
-    .map(network => AssetUtil.getNetworkImage(network, networkImages))
+    .map(network => AssetUtil.getNetworkImage(network, AssetController.state.networkImages))
     .filter(Boolean) as string[];
 
   const label = UiUtil.getTruncateString({

--- a/packages/scaffold/src/views/w3m-wallet-send-preview-view/components/preview-send-details.tsx
+++ b/packages/scaffold/src/views/w3m-wallet-send-preview-view/components/preview-send-details.tsx
@@ -1,4 +1,5 @@
-import { AssetUtil, type CaipNetwork } from '@reown/appkit-core-react-native';
+import { useSnapshot } from 'valtio';
+import { AssetController, AssetUtil, type CaipNetwork } from '@reown/appkit-core-react-native';
 import {
   BorderRadius,
   FlexView,
@@ -26,6 +27,7 @@ export function PreviewSendDetails({
   style
 }: PreviewSendDetailsProps) {
   const Theme = useTheme();
+  const { networkImages } = useSnapshot(AssetController.state);
 
   const formattedName = UiUtil.getTruncateString({
     string: name ?? '',
@@ -41,7 +43,7 @@ export function PreviewSendDetails({
     truncate: 'middle'
   });
 
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
 
   return (
     <FlexView

--- a/packages/scaffold/src/views/w3m-wallet-send-select-token-view/index.tsx
+++ b/packages/scaffold/src/views/w3m-wallet-send-select-token-view/index.tsx
@@ -4,6 +4,7 @@ import { ScrollView } from 'react-native';
 import { FlexView, InputText, ListToken, Text } from '@reown/appkit-ui-react-native';
 import {
   AccountController,
+  AssetController,
   AssetUtil,
   NetworkController,
   RouterController,
@@ -20,7 +21,8 @@ export function WalletSendSelectTokenView() {
   const { tokenBalance } = useSnapshot(AccountController.state);
   const { caipNetwork } = useSnapshot(NetworkController.state);
   const { token } = useSnapshot(SendController.state);
-  const networkImage = AssetUtil.getNetworkImage(caipNetwork);
+  const { networkImages } = useSnapshot(AssetController.state);
+  const networkImage = AssetUtil.getNetworkImage(caipNetwork, networkImages);
   const [tokenSearch, setTokenSearch] = useState<string>('');
   const [filteredTokens, setFilteredTokens] = useState(tokenBalance ?? []);
 

--- a/packages/ui/src/composites/wui-card-select/index.tsx
+++ b/packages/ui/src/composites/wui-card-select/index.tsx
@@ -100,5 +100,5 @@ function _CardSelect({
 }
 
 export const CardSelect = memo(_CardSelect, (prevProps, nextProps) => {
-  return prevProps.name === nextProps.name;
+  return prevProps.name === nextProps.name && prevProps.imageSrc === nextProps.imageSrc;
 });

--- a/packages/ui/src/composites/wui-network-image/index.tsx
+++ b/packages/ui/src/composites/wui-network-image/index.tsx
@@ -1,9 +1,8 @@
-import { Path, Svg, Image, Defs, Pattern } from 'react-native-svg';
+import { Path, Svg, Image, Defs, Pattern, G } from 'react-native-svg';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { useTheme } from '../../hooks/useTheme';
 import type { SizeType } from '../../utils/TypesUtil';
-import { Icon } from '../../components/wui-icon';
-import { FlexView } from '../../layout/wui-flex';
+import NetworkPlaceholderSvg from '../../assets/svg/NetworkPlaceholder';
 import { PathLg, PathNormal, PathSmall, PathXS } from './styles';
 
 export interface NetworkImageProps {
@@ -31,6 +30,13 @@ const sizeToHeight = {
   xs: 20
 };
 
+const sizeToIconSize = {
+  lg: 24,
+  md: 16,
+  sm: 14,
+  xs: 12
+};
+
 export function NetworkImage({
   imageSrc,
   imageHeaders,
@@ -44,42 +50,52 @@ export function NetworkImage({
   const Theme = useTheme();
   const svgStroke = selected ? Theme['accent-100'] : Theme['gray-glass-010'];
   const opacity = disabled ? 0.5 : 1;
+  const containerSize = sizeToHeight[size];
+  const iconSize = sizeToIconSize[size];
 
   return (
     <Svg
-      width={sizeToHeight[size]}
-      height={sizeToHeight[size]}
+      width={containerSize}
+      height={containerSize}
       stroke={borderColor ?? svgStroke}
       strokeWidth={borderWidth}
       style={style}
     >
-      <Defs>
-        <Pattern id="image-pattern">
-          {imageSrc ? (
-            <Image
-              height={sizeToHeight[size]}
-              width={sizeToHeight[size]}
-              opacity={opacity}
-              href={{ uri: imageSrc, headers: imageHeaders }}
-            />
-          ) : (
-            <FlexView
-              alignItems="center"
-              justifyContent="center"
-              // eslint-disable-next-line react-native/no-inline-styles
-              style={{
-                height: sizeToHeight[size],
-                width: sizeToHeight[size],
-                backgroundColor: 'transparent'
-              }}
+      {imageSrc ? (
+        <>
+          <Defs>
+            <Pattern
+              id="image-pattern"
+              width={containerSize}
+              height={containerSize}
+              patternUnits="userSpaceOnUse"
             >
-              <Icon name="networkPlaceholder" size={size} color="fg-200" />
-            </FlexView>
-          )}
-        </Pattern>
-      </Defs>
-      {!imageSrc && <Path d={sizeToPath[size]} opacity={opacity} fill={Theme['gray-glass-005']} />}
-      <Path d={sizeToPath[size]} opacity={opacity} fill="url(#image-pattern)" />
+              <Image
+                height={containerSize}
+                width={containerSize}
+                opacity={opacity}
+                href={{ uri: imageSrc, headers: imageHeaders }}
+              />
+            </Pattern>
+          </Defs>
+          <Path d={sizeToPath[size]} opacity={opacity} fill="url(#image-pattern)" />
+        </>
+      ) : (
+        <>
+          <Path d={sizeToPath[size]} opacity={opacity} fill={Theme['gray-glass-005']} />
+          <G
+            transform={`translate(${(containerSize - iconSize) / 2}, ${
+              (containerSize - iconSize) / 2
+            })`}
+          >
+            <NetworkPlaceholderSvg
+              fill={selected ? Theme['accent-100'] : Theme['fg-200']}
+              width={iconSize}
+              height={iconSize}
+            />
+          </G>
+        </>
+      )}
     </Svg>
   );
 }


### PR DESCRIPTION
This pull request addresses a bug with displaying network images in the React Native appkit packages. The main change is to ensure network images are shown correctly across the app by updating how network image data is accessed and passed through various components. The fix involves modifying the `AssetUtil.getNetworkImage` utility to accept a `networkImages` mapping and updating all usages to provide this data from `AssetController.state`.

**Bug fix: Network images display**

* Updated `AssetUtil.getNetworkImage` to accept a second parameter, `networkImages`, allowing it to reliably fetch network images using either the network's `imageUrl` or its `imageId` from the provided mapping.
* Refactored all components and views that display network images (e.g., `AccountButton`, `NetworkButton`, `AccountActivity`, `AccountTokens`, `SelectorModal`, `AccountDefaultView`, `AccountView`, `NetworkSwitchView`, `NetworksView`, `OnRampView`, `SwapSelectTokenView`, `UnsupportedChainView`, `WalletCompatibleNetworks`) to import `AssetController`, retrieve `networkImages` from its state, and pass it to `AssetUtil.getNetworkImage`. [[1]](diffhunk://#diff-7e2f3b18be6d53c49caee277dcc851fd081914fb1dcb708f867ab332a8a4527aL10-R11) [[2]](diffhunk://#diff-7e2f3b18be6d53c49caee277dcc851fd081914fb1dcb708f867ab332a8a4527aR31-R34) [[3]](diffhunk://#diff-ca4f595f9a5f1bf633cc345fb39656e775c81f75b5ea90cc475a85c2f4c93271R6) [[4]](diffhunk://#diff-ca4f595f9a5f1bf633cc345fb39656e775c81f75b5ea90cc475a85c2f4c93271R22) [[5]](diffhunk://#diff-ca4f595f9a5f1bf633cc345fb39656e775c81f75b5ea90cc475a85c2f4c93271L36-R38) [[6]](diffhunk://#diff-6725d846733b1dd3068a71eea9c8aaf8cd6ad716061ce4404645132a4e114065R16) [[7]](diffhunk://#diff-6725d846733b1dd3068a71eea9c8aaf8cd6ad716061ce4404645132a4e114065L36-R38) [[8]](diffhunk://#diff-f042ca89b6d37ba39ec4074455c4ea5af2f446439d767295bac62834e52c9da1R12) [[9]](diffhunk://#diff-f042ca89b6d37ba39ec4074455c4ea5af2f446439d767295bac62834e52c9da1L34-R36) [[10]](diffhunk://#diff-4bdd29e44161e054eb5e14c593998d22f6e53b43ab7931e0d27691d8218131fdL16-R16) [[11]](diffhunk://#diff-4bdd29e44161e054eb5e14c593998d22f6e53b43ab7931e0d27691d8218131fdL49-R50) [[12]](diffhunk://#diff-24c1f32ac6010c5afb07a5c4ea34028a72811f00136b69ede23c7d21858aca35L21-R22) [[13]](diffhunk://#diff-24c1f32ac6010c5afb07a5c4ea34028a72811f00136b69ede23c7d21858aca35L55-R57) [[14]](diffhunk://#diff-9ba1dca952f68790daa01d0a048ec88670929ca27ad1a16fa8c8572d0942a62fR16) [[15]](diffhunk://#diff-9ba1dca952f68790daa01d0a048ec88670929ca27ad1a16fa8c8572d0942a62fR32) [[16]](diffhunk://#diff-9ba1dca952f68790daa01d0a048ec88670929ca27ad1a16fa8c8572d0942a62fL77-R79) [[17]](diffhunk://#diff-696d6dd5c8ad132a25dfdd855a2d6133ad4c422c8dd3c26074823d58df4a6f11R6) [[18]](diffhunk://#diff-696d6dd5c8ad132a25dfdd855a2d6133ad4c422c8dd3c26074823d58df4a6f11R25-R31) [[19]](diffhunk://#diff-696d6dd5c8ad132a25dfdd855a2d6133ad4c422c8dd3c26074823d58df4a6f11L118-R123) [[20]](diffhunk://#diff-70d200bc0a1e81e2ddaea323d30bb66d6f247b9c88ca9d19d6c35ef5b6f623a8R1) [[21]](diffhunk://#diff-70d200bc0a1e81e2ddaea323d30bb66d6f247b9c88ca9d19d6c35ef5b6f623a8L19-R29) [[22]](diffhunk://#diff-70d200bc0a1e81e2ddaea323d30bb66d6f247b9c88ca9d19d6c35ef5b6f623a8L72-R75) [[23]](diffhunk://#diff-4429800d77d57d8c4fcb7d6e074bc3e0c20dc2a8127df52567af920cf8ad658dL13-R14) [[24]](diffhunk://#diff-4429800d77d57d8c4fcb7d6e074bc3e0c20dc2a8127df52567af920cf8ad658dR54-R60) [[25]](diffhunk://#diff-2f542751734f1cb38f9cbf59f9b1175a7151ebfca2fc34ba0519ce82292e5d97R16) [[26]](diffhunk://#diff-2f542751734f1cb38f9cbf59f9b1175a7151ebfca2fc34ba0519ce82292e5d97L33-R35) [[27]](diffhunk://#diff-e70a72fa8aac1a5616a0e464881012d270ee35de40fc8f235e61e92aaa674e99L14-R22) [[28]](diffhunk://#diff-e70a72fa8aac1a5616a0e464881012d270ee35de40fc8f235e61e92aaa674e99L62-R64) [[29]](diffhunk://#diff-a582cb1eabc806be9c54ab843becd3f6ae86cea8a052c7b6dc1bbbd31d2b18a8R7) [[30]](diffhunk://#diff-a582cb1eabc806be9c54ab843becd3f6ae86cea8a052c7b6dc1bbbd31d2b18a8R17)

These changes ensure that network images are consistently and correctly displayed throughout the app, resolving previous issues where they may not have appeared due to missing or incorrect image data.