### PR TITLE
Fix: update state correctly after switching chain + small changes

### DIFF
--- a/apps/native/src/components/DisconnectButton.tsx
+++ b/apps/native/src/components/DisconnectButton.tsx
@@ -1,10 +1,10 @@
 import { StyleSheet } from 'react-native';
+import { useAccount, useAppKit } from '@reown/appkit-react-native';
 import { Button } from '@reown/appkit-ui-react-native';
-import { useAccount, useDisconnect } from 'wagmi';
 
 export function DisconnectButton() {
+  const { disconnect } = useAppKit();
   const { isConnected } = useAccount();
-  const { disconnect } = useDisconnect();
 
   return isConnected ? (
     <Button testID="disconnect-hook-button" style={styles.button} onPress={() => disconnect()}>

--- a/apps/native/src/components/OpenButton.tsx
+++ b/apps/native/src/components/OpenButton.tsx
@@ -1,7 +1,6 @@
 import { StyleSheet } from 'react-native';
+import { useAppKit, useAccount } from '@reown/appkit-react-native';
 import { Button } from '@reown/appkit-ui-react-native';
-import { useAppKit } from '@reown/appkit-react-native';
-import { useAccount } from 'wagmi';
 
 export function OpenButton() {
   const { open } = useAppKit();

--- a/apps/native/src/views/WagmiActionsView.tsx
+++ b/apps/native/src/views/WagmiActionsView.tsx
@@ -1,6 +1,7 @@
-import { Button, Text, FlexView } from '@reown/appkit-ui-react-native';
 import { StyleSheet } from 'react-native';
-import { useSignMessage, useAccount, useSendTransaction, useEstimateGas } from 'wagmi';
+import { useAccount } from '@reown/appkit-react-native';
+import { Button, Text, FlexView } from '@reown/appkit-ui-react-native';
+import { useSignMessage, useSendTransaction, useEstimateGas } from 'wagmi';
 import { Hex, parseEther } from 'viem';
 import { SendTransactionData, SignMessageData } from 'wagmi/query';
 import { ToastUtils } from '../utils/ToastUtils';

--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -511,7 +511,7 @@ export class AppKit {
     }
   }
 
-  private async refreshBalance(fetchAllBalances: boolean = false) {
+  private refreshBalance(fetchAllBalances: boolean = false) {
     try {
       if (fetchAllBalances) {
         ConnectionsController.fetchBalance();
@@ -548,7 +548,6 @@ export class AppKit {
     const recomputePolling = () => {
       const open = ModalController.state.open;
       const view = RouterController.state.view;
-
       if (open && (view === 'Account' || view === 'AccountDefault')) {
         // fetch all balances when user is using embedded wallet
         this.startBalancePolling(view === 'Account');
@@ -556,9 +555,7 @@ export class AppKit {
         this.stopBalancePolling();
       }
     };
-
     recomputePolling();
-
     subscribeKey(RouterController.state, 'view', () => recomputePolling());
     subscribeKey(ModalController.state, 'open', () => recomputePolling());
   }
@@ -644,7 +641,7 @@ export class AppKit {
 
       // Check if user needs to sign in again
       if (namespace === 'eip155') {
-        await this.handleSiweChange({ isNetworkChange: true });
+        this.handleSiweChange({ isNetworkChange: true });
       }
     });
 

--- a/packages/common/src/types/api/wallet-api.ts
+++ b/packages/common/src/types/api/wallet-api.ts
@@ -14,6 +14,7 @@ export interface WcWallet {
   app_store?: string | null;
   play_store?: string | null;
   chains?: readonly CaipNetworkId[];
+  badge_type?: 'certified' | 'none';
 }
 
 export interface DataWallet {

--- a/packages/core/src/controllers/ConnectionsController.ts
+++ b/packages/core/src/controllers/ConnectionsController.ts
@@ -80,11 +80,13 @@ const updateConnection = (
   namespace: ChainNamespace,
   connection: Connection,
   updates: Partial<Connection>
-) => {
-  if (!connection) return;
+): Connection => {
   const newConnectionsMap = new Map(baseState.connections);
-  newConnectionsMap.set(namespace, { ...connection, ...updates });
+  const newConnection = { ...connection, ...updates };
+  newConnectionsMap.set(namespace, newConnection);
   baseState.connections = newConnectionsMap;
+
+  return newConnection;
 };
 
 const getActiveIdentity = (connection: Connection): Identity | undefined => {
@@ -206,6 +208,10 @@ export const ConnectionsController = {
   state: derivedState,
 
   setActiveNamespace(namespace?: ChainNamespace) {
+    if (baseState.activeNamespace === namespace) {
+      return;
+    }
+
     baseState.activeNamespace = namespace;
     StorageUtil.setActiveNamespace(namespace);
   },
@@ -257,10 +263,7 @@ export const ConnectionsController = {
       return false;
     }
 
-    const newConnectionsMap = new Map(baseState.connections);
-    const updatedConnection = { ...connection, accounts };
-    newConnectionsMap.set(namespace, updatedConnection);
-    baseState.connections = newConnectionsMap;
+    updateConnection(namespace, connection, { accounts });
 
     return true;
   },
@@ -333,10 +336,7 @@ export const ConnectionsController = {
       return;
     }
 
-    baseState.connections.set(namespace, {
-      ...connection,
-      caipNetwork: networkId
-    });
+    updateConnection(namespace, connection, { caipNetwork: networkId });
 
     this.setActiveNamespace(namespace);
   },
@@ -381,10 +381,7 @@ export const ConnectionsController = {
     const connection = baseState.connections.get(namespace);
     if (!connection) return;
 
-    const newConnectionsMap = new Map(baseState.connections);
-    const newConnection = { ...connection, type };
-    newConnectionsMap.set(namespace, newConnection);
-    baseState.connections = newConnectionsMap;
+    const newConnection = updateConnection(namespace, connection, { type });
 
     return getActiveAddress(newConnection);
   },


### PR DESCRIPTION
**Connection state management refactor:**
* Refactored connection updates in `ConnectionsController.ts` to use a new `updateConnection` helper, centralizing logic for updating connections and returning the updated object. This improves code maintainability and reduces duplication. [[1]](diffhunk://#diff-68c9947de03833ee5f6205e289907e422a90b7028de3f64f125e9165882f7079L83-R89) [[2]](diffhunk://#diff-68c9947de03833ee5f6205e289907e422a90b7028de3f64f125e9165882f7079L260-R266) [[3]](diffhunk://#diff-68c9947de03833ee5f6205e289907e422a90b7028de3f64f125e9165882f7079L336-R339) [[4]](diffhunk://#diff-68c9947de03833ee5f6205e289907e422a90b7028de3f64f125e9165882f7079L384-R384)
* Added a guard in `setActiveNamespace` to avoid unnecessary state updates if the namespace hasn't changed.

**Type and API enhancements:**
* Added a `badge_type` field to the `WcWallet` interface to support wallet certification status.

**React Native hook standardization:**
* Updated `DisconnectButton.tsx` and `OpenButton.tsx` to use hooks from `@reown/appkit-react-native` instead of `wagmi`, ensuring consistency and reducing external dependencies. [[1]](diffhunk://#diff-dea52431d75b9e3bf70d3b981ff0375cc1956febb1f6051aaadada17aa4bfb70R2-L7) [[2]](diffhunk://#diff-2c1f63c4b5cfd483e0d448df3b0c04885bf17671b08b8efc5d27c593204d03c5R2-L4)
* Updated `WagmiActionsView.tsx` to use `useAccount` from `@reown/appkit-react-native` for improved integration, while keeping some `wagmi` hooks where necessary.

**Minor internal improvements:**
* Made `refreshBalance` and `handleSiweChange` in `AppKit.ts` synchronous, removing unnecessary `async`/`await` usage. [[1]](diffhunk://#diff-3682d6df4945029dc63dcd74cbe7c82918ca879287935c7919862f24f0633559L514-R514) [[2]](diffhunk://#diff-3682d6df4945029dc63dcd74cbe7c82918ca879287935c7919862f24f0633559L647-R644)
* Cleaned up whitespace and redundant lines in `AppKit.ts` for readability.