### PR TITLE
feat: change appkit theme mode automatically if no default value is set

### DIFF
--- a/packages/appkit/src/AppKit.ts
+++ b/packages/appkit/src/AppKit.ts
@@ -675,7 +675,7 @@ export class AppKit {
       OptionsController.setDefaultNetwork(network);
     }
 
-    ThemeController.setThemeMode(options.themeMode);
+    ThemeController.setDefaultThemeMode(options.themeMode);
     ThemeController.setThemeVariables(options.themeVariables);
 
     OptionsController.setSdkVersion(

--- a/packages/appkit/src/modal/w3m-modal/index.tsx
+++ b/packages/appkit/src/modal/w3m-modal/index.tsx
@@ -1,5 +1,6 @@
 import { useSnapshot } from 'valtio';
 import { useCallback, useEffect } from 'react';
+import { useColorScheme } from 'react-native';
 import { Card, Modal, ThemeProvider } from '@reown/appkit-ui-react-native';
 import {
   ApiController,
@@ -18,10 +19,11 @@ import { useInternalAppKit } from '../../AppKitContext';
 import styles from './styles';
 
 export function AppKit() {
+  const theme = useColorScheme();
   const { bottom, top } = useSafeAreaInsets();
   const { close } = useInternalAppKit();
   const { open } = useSnapshot(ModalController.state);
-  const { themeMode, themeVariables } = useSnapshot(ThemeController.state);
+  const { themeMode, themeVariables, defaultThemeMode } = useSnapshot(ThemeController.state);
   const { projectId } = useSnapshot(OptionsController.state);
 
   const handleBackPress = () => {
@@ -31,6 +33,12 @@ export function AppKit() {
 
     return handleModalClose();
   };
+
+  useEffect(() => {
+    if (theme && !defaultThemeMode) {
+      ThemeController.setThemeMode(theme);
+    }
+  }, [theme, defaultThemeMode]);
 
   const prefetch = useCallback(async () => {
     await ApiController.prefetch();

--- a/packages/core/src/controllers/ThemeController.ts
+++ b/packages/core/src/controllers/ThemeController.ts
@@ -5,12 +5,14 @@ import type { ThemeMode, ThemeVariables } from '@reown/appkit-common-react-nativ
 // -- Types --------------------------------------------- //
 export interface ThemeControllerState {
   themeMode?: ThemeMode;
+  defaultThemeMode?: ThemeMode;
   themeVariables?: ThemeVariables;
 }
 
 // -- State --------------------------------------------- //
 const state = proxy<ThemeControllerState>({
   themeMode: undefined,
+  defaultThemeMode: undefined,
   themeVariables: {}
 });
 
@@ -28,6 +30,11 @@ export const ThemeController = {
     } else {
       state.themeMode = themeMode;
     }
+  },
+
+  setDefaultThemeMode(themeMode: ThemeControllerState['defaultThemeMode']) {
+    state.defaultThemeMode = themeMode;
+    this.setThemeMode(themeMode);
   },
 
   setThemeVariables(themeVariables: ThemeControllerState['themeVariables']) {


### PR DESCRIPTION
Theme management improvements:

* Added a `defaultThemeMode` property to the `ThemeController` state and implemented a new `setDefaultThemeMode` method that sets both the default and active theme mode. (`packages/core/src/controllers/ThemeController.ts`) [[1]](diffhunk://#diff-33cbf4f96e58e19ce2eb03efc85d1f8a1441bbfcf8d4ee5b389aba008b4fe643R8-R15) [[2]](diffhunk://#diff-33cbf4f96e58e19ce2eb03efc85d1f8a1441bbfcf8d4ee5b389aba008b4fe643R35-R39)
* Updated `AppKit` initialization to use `ThemeController.setDefaultThemeMode` instead of directly setting the theme mode, ensuring the default is tracked and applied consistently. (`packages/appkit/src/AppKit.ts`)

System color scheme support:

* In the modal component, added support for detecting the system color scheme using `useColorScheme` and, if no default theme is set, automatically applying the system theme. (`packages/appkit/src/modal/w3m-modal/index.tsx`) [[1]](diffhunk://#diff-a9039eb8970448586068260e82cab6f105bf99dc929c22f0a75b1623dea1603bR3) [[2]](diffhunk://#diff-a9039eb8970448586068260e82cab6f105bf99dc929c22f0a75b1623dea1603bR22-R26) [[3]](diffhunk://#diff-a9039eb8970448586068260e82cab6f105bf99dc929c22f0a75b1623dea1603bR37-R42)